### PR TITLE
Ensure `active_job` events are safe for non-Lambdakiq jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-
 # Keep A Changelog!
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
+
+## v1.0.2
+
+#### Fixed
+
+- Ensure `active_job` events are safe for non-Lambdakiq jobs.
 
 ## v1.0.0
 
 #### Added
 
-* Initial release.
+- Initial release.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lambdakiq (1.0.1)
+    lambdakiq (1.0.2)
       activejob
       aws-sdk-sqs
       concurrent-ruby

--- a/lib/lambdakiq/metrics.rb
+++ b/lib/lambdakiq/metrics.rb
@@ -16,6 +16,7 @@ module Lambdakiq
     end
 
     def log
+      return unless lambdakiq?
       logger.info JSON.dump(message)
     end
 
@@ -27,6 +28,10 @@ module Lambdakiq
 
     def job_name
       job.class.name
+    end
+
+    def lambdakiq?
+      job.respond_to?(:lambdakiq?) && job.lambdakiq?
     end
 
     def logger

--- a/lib/lambdakiq/version.rb
+++ b/lib/lambdakiq/version.rb
@@ -1,3 +1,3 @@
 module Lambdakiq
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/lib/lambdakiq/worker.rb
+++ b/lib/lambdakiq/worker.rb
@@ -16,6 +16,10 @@ module Lambdakiq
 
     end
 
+    def lambdakiq?
+      true
+    end
+
     def lambdakiq_retry
       lambdakiq_options_hash[:retry]
     end


### PR DESCRIPTION
Noticed this when use other or :test adapters outside of production.