### PR TITLE
Move to `ReportBatchItemFailures` Mode. Fixes #22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v2.0.0
+
+#### Changed
+
+- Leverage new `ReportBatchItemFailures` feature of SQS.
+
 ## v1.0.2, v1.0.3, v1.0.4
 
 #### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lambdakiq (1.0.4)
+    lambdakiq (2.0.0)
       activejob
       aws-sdk-sqs
       concurrent-ruby

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ JobsLambda:
         Properties:
           Queue: !GetAtt JobsQueue.Arn
           BatchSize: 1
+          FunctionResponseTypes:
+            - ReportBatchItemFailures
     MemorySize: 1792
     PackageType: Image
     Policies:

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ JobsLambda:
 Here are some key aspects of our `JobsLambda` resource above:
 
 - The `Events` property uses the [SQS Type](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-sqs.html).
-- Our [BatchSize](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-sqs.html#sam-function-sqs-batchsize) is set to one so we can handle retrys more easily without worrying about idempotency in larger batches.
+- The [BatchSize](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-sqs.html#sam-function-sqs-batchsize) can be any number you like. Less means more Lambda concurrency, more means some jobs could take longer. The jobs function `Timeout` must be lower than the `JobsQueue`'s `VisibilityTimeout` property. When the batch size is one, the queue's visibility is generally one second more.
+- You must use `ReportBatchItemFailures` response types. Lambdakiq assumes we are [reporting batch item failures](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting). This is a new feature of SQS introduced in [November 2021](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting).
 - The `Metadata`'s Docker properties must be the same as our web function except for the `DockerTag`. This is needed for the image to be shared. This works around a known [SAM issue](https://github.com/aws/aws-sam-cli/issues/2466) vs using the `ImageConfig` property.
-- The jobs function `Timeout` must be lower than the `JobsQueue`'s `VisibilityTimeout` property. When the batch size is one, the queue's visibility is generally one second more.
 
 🎉 Deploy your application and have fun with ActiveJob on SQS & Lambda.
 
@@ -193,12 +193,6 @@ end
 ```
 
 - `retry` - Overrides the default Lambdakiq `max_retries` for this one job.
-
-## Concurrency & Limits
-
-AWS SQS is highly scalable with [few limits](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-quotas.html). As your jobs in SQS increases so should your concurrent functions to process that work. However, as this article, ["Why isn't my Lambda function with an Amazon SQS event source scaling optimally?"](https://aws.amazon.com/premiumsupport/knowledge-center/lambda-sqs-scaling/) describes it is possible that errors will effect your concurrency.
-
-To help keep your queue and workers scalable, reduce the errors raised by your jobs. You an also reduce the retry count.
 
 ## Observability with CloudWatch
 

--- a/lib/lambdakiq/error.rb
+++ b/lib/lambdakiq/error.rb
@@ -2,16 +2,6 @@ module Lambdakiq
   class Error < StandardError
   end
 
-  class JobError < Error
-    attr_reader :original_exception, :job
-
-    def initialize(error)
-      @original_exception = error
-      super(error.message)
-      set_backtrace Rails.backtrace_cleaner.clean(error.backtrace)
-    end
-  end
-
   class FifoDelayError < Error
     def initialize(error)
       super

--- a/lib/lambdakiq/job.rb
+++ b/lib/lambdakiq/job.rb
@@ -10,8 +10,8 @@ module Lambdakiq
         jobs = records.map { |record| new(record) }
         jobs.each(&:perform)
         failed_jobs = jobs.select { |j| j.error }
-        item_failures = failed_jobs.map { |j| { ItemIdentifier: j.provider_job_id } }
-        { BatchItemFailures: item_failures }
+        item_failures = failed_jobs.map { |j| { itemIdentifier: j.provider_job_id } }
+        { batchItemFailures: item_failures }
       end
 
     end

--- a/lib/lambdakiq/version.rb
+++ b/lib/lambdakiq/version.rb
@@ -1,3 +1,3 @@
 module Lambdakiq
-  VERSION = '1.0.4'
+  VERSION = '2.0.0'
 end

--- a/test/cases/job_test.rb
+++ b/test/cases/job_test.rb
@@ -3,14 +3,14 @@ require 'test_helper'
 class JobTest < LambdakiqSpec
 
   it '#active_job - a deserialize representation of what will be executed' do
-    e = event_basic messageId: '9081fe74-bc79-451f-a03a-2fe5c6e2f807'
+    e = event_basic messageId: message_id
     aj = job(event: e).active_job
     expect(aj).must_be_instance_of TestHelper::Jobs::BasicJob
     expect(aj.job_id).must_equal '527cd37e-08f4-4aa8-9834-a46220cdc5a3'
     expect(aj.queue_name).must_equal queue_name
     expect(aj.enqueued_at).must_equal '2020-11-30T13:07:36Z'
     expect(aj.executions).must_equal 0
-    expect(aj.provider_job_id).must_equal '9081fe74-bc79-451f-a03a-2fe5c6e2f807'
+    expect(aj.provider_job_id).must_equal message_id
   end
 
   it '#active_job - executions uses ApproximateReceiveCount' do
@@ -20,7 +20,8 @@ class JobTest < LambdakiqSpec
   end
 
   it 'must perform basic job' do
-    Lambdakiq::Job.handler(event_basic)
+    response = Lambdakiq::Job.handler(event_basic)
+    assert_response response, failures: false
     expect(delete_message).must_be :present?
     expect(change_message_visibility).must_be_nil
     expect(perform_buffer_last_value).must_equal 'BasicJob with: "test"'
@@ -29,7 +30,8 @@ class JobTest < LambdakiqSpec
   end
 
   it 'logs cloudwatch embedded metrics' do
-    Lambdakiq::Job.handler(event_basic(messageId: '9081fe74-bc79-451f-a03a-2fe5c6e2f807'))
+    response = Lambdakiq::Job.handler(event_basic(messageId: message_id))
+    assert_response response, failures: false
     metric = logged_metric('perform.active_job')
     expect(metric).must_be :present?
     expect(metric['AppName']).must_equal 'Dummy'
@@ -37,13 +39,14 @@ class JobTest < LambdakiqSpec
     expect(metric['Duration']).must_equal 0
     expect(metric['JobId']).must_equal '527cd37e-08f4-4aa8-9834-a46220cdc5a3'
     expect(metric['QueueName']).must_equal 'lambdakiq-JobsQueue-TESTING123.fifo'
-    expect(metric['MessageId']).must_equal '9081fe74-bc79-451f-a03a-2fe5c6e2f807'
+    expect(metric['MessageId']).must_equal message_id
     expect(metric['JobArg1']).must_equal 'test'
   end
 
   it 'must change message visibility to next value for failed jobs' do
-    event = event_basic attributes: { ApproximateReceiveCount: '7' }, job_class: 'TestHelper::Jobs::ErrorJob'
-    expect(->{ Lambdakiq::Job.handler(event) }).must_raise 'HELL'
+    event = event_basic attributes: { ApproximateReceiveCount: '7' }, job_class: 'TestHelper::Jobs::ErrorJob', messageId: message_id
+    response = Lambdakiq::Job.handler(event)
+    assert_response response, failures: true, identifiers: [message_id]
     expect(change_message_visibility).must_be :present?
     expect(change_message_visibility_params[:visibility_timeout]).must_equal 1416
     expect(perform_buffer_last_value).must_equal 'ErrorJob with: "test"'
@@ -58,10 +61,20 @@ class JobTest < LambdakiqSpec
   end
 
   it 'wraps returned errors with no backtrace which avoids excessive/duplicate cloudwatch logging' do
-    event = event_basic job_class: 'TestHelper::Jobs::ErrorJob'
-    error = expect(->{ Lambdakiq::Job.handler(event) }).must_raise 'HELL'
-    expect(error.class.name).must_equal 'Lambdakiq::JobError'
-    expect(error.backtrace).must_equal []
+    event = event_basic job_class: 'TestHelper::Jobs::ErrorJob', messageId: message_id
+    response = Lambdakiq::Job.handler(event)
+    assert_response response, failures: true, identifiers: [message_id]
+    expect(perform_buffer_last_value).must_equal 'ErrorJob with: "test"'
+    expect(logger).must_include 'Performing TestHelper::Jobs::ErrorJob'
+    expect(logger).must_include 'Error performing TestHelper::Jobs::ErrorJob'
+  end
+
+  it 'can handle batches with partial failures' do
+    event = event_basic
+    error = event_basic job_class: 'TestHelper::Jobs::ErrorJob', messageId: message_id
+    event['Records'].push error['Records'].first
+    response = Lambdakiq::Job.handler(event)
+    assert_response response, failures: true, identifiers: [message_id]
     expect(perform_buffer_last_value).must_equal 'ErrorJob with: "test"'
     expect(logger).must_include 'Performing TestHelper::Jobs::ErrorJob'
     expect(logger).must_include 'Error performing TestHelper::Jobs::ErrorJob'
@@ -70,7 +83,8 @@ class JobTest < LambdakiqSpec
   it 'must delete message for failed jobs at the end of the queue/message max receive count' do
     # See ClientHelpers for setting queue to max receive count of 8.
     event = event_basic attributes: { ApproximateReceiveCount: '8' }, job_class: 'TestHelper::Jobs::ErrorJob'
-    Lambdakiq::Job.handler(event)
+    response = Lambdakiq::Job.handler(event)
+    assert_response response, failures: false
     expect(delete_message).must_be :present?
     expect(perform_buffer_last_value).must_equal 'ErrorJob with: "test"'
     expect(logger).must_include 'Performing TestHelper::Jobs::ErrorJob'
@@ -83,8 +97,9 @@ class JobTest < LambdakiqSpec
   end
 
   it 'must not perform and allow fifo queue to use message visibility as delay' do
-    event = event_basic_delay minutes: 6
-    error = expect(->{ Lambdakiq::Job.handler(event) }).must_raise 'HELL'
+    event = event_basic_delay minutes: 6, overrides: { messageId: message_id }
+    response = Lambdakiq::Job.handler(event)
+    assert_response response, failures: true, identifiers: [message_id]
     expect(delete_message).must_be :blank?
     expect(change_message_visibility).must_be :present?
     expect(change_message_visibility_params[:visibility_timeout]).must_be_close_to 6.minutes, 1
@@ -93,8 +108,9 @@ class JobTest < LambdakiqSpec
   end
 
   it 'must not perform and allow fifo queue to use message visibility as delay (using SentTimestamp)' do
-    event = event_basic_delay minutes: 10, timestamp: 2.minutes.ago.strftime('%s%3N')
-    error = expect(->{ Lambdakiq::Job.handler(event) }).must_raise 'HELL'
+    event = event_basic_delay minutes: 10, timestamp: 2.minutes.ago.strftime('%s%3N'), overrides: { messageId: message_id }
+    response = Lambdakiq::Job.handler(event)
+    assert_response response, failures: true, identifiers: [message_id]
     expect(delete_message).must_be :blank?
     expect(change_message_visibility).must_be :present?
     expect(change_message_visibility_params[:visibility_timeout]).must_be_close_to 8.minutes, 1
@@ -104,7 +120,8 @@ class JobTest < LambdakiqSpec
 
   it 'must perform and allow fifo queue to use message visibility as delay but not when SentTimestamp is too far in the past' do
     event = event_basic_delay minutes: 2, timestamp: 3.minutes.ago.strftime('%s%3N')
-    Lambdakiq::Job.handler(event)
+    response = Lambdakiq::Job.handler(event)
+    assert_response response, failures: false
     expect(delete_message).must_be :present?
     expect(change_message_visibility).must_be_nil
     expect(perform_buffer_last_value).must_equal 'BasicJob with: "test"'
@@ -114,7 +131,8 @@ class JobTest < LambdakiqSpec
 
   it 'must use `lambdakiq_options` retry options set to 0 and not retry job' do
     event = event_basic job_class: 'TestHelper::Jobs::ErrorJobNoRetry'
-    Lambdakiq::Job.handler(event)
+    response = Lambdakiq::Job.handler(event)
+    assert_response response, failures: false
     expect(delete_message).must_be :present?
     expect(perform_buffer_last_value).must_equal 'ErrorJobNoRetry with: "test"'
     expect(logger).must_include 'Performing TestHelper::Jobs::ErrorJobNoRetry'
@@ -122,8 +140,9 @@ class JobTest < LambdakiqSpec
   end
 
   it 'must use `lambdakiq_options` retry options set to 1 and retry job' do
-    event = event_basic job_class: 'TestHelper::Jobs::ErrorJobOneRetry'
-    error = expect(->{ Lambdakiq::Job.handler(event) }).must_raise 'HELL'
+    event = event_basic job_class: 'TestHelper::Jobs::ErrorJobOneRetry', messageId: message_id
+    response = Lambdakiq::Job.handler(event)
+    assert_response response, failures: true, identifiers: [message_id]
     expect(delete_message).must_be :blank?
     expect(perform_buffer_last_value).must_equal 'ErrorJobOneRetry with: "test"'
     expect(change_message_visibility).must_be :present?

--- a/test/cases/job_test.rb
+++ b/test/cases/job_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 class JobTest < LambdakiqSpec
 
   it '#active_job - a deserialize representation of what will be executed' do
-    aj = job.active_job
+    e = event_basic messageId: '9081fe74-bc79-451f-a03a-2fe5c6e2f807'
+    aj = job(event: e).active_job
     expect(aj).must_be_instance_of TestHelper::Jobs::BasicJob
     expect(aj.job_id).must_equal '527cd37e-08f4-4aa8-9834-a46220cdc5a3'
     expect(aj.queue_name).must_equal queue_name
@@ -28,7 +29,7 @@ class JobTest < LambdakiqSpec
   end
 
   it 'logs cloudwatch embedded metrics' do
-    Lambdakiq::Job.handler(event_basic)
+    Lambdakiq::Job.handler(event_basic(messageId: '9081fe74-bc79-451f-a03a-2fe5c6e2f807'))
     metric = logged_metric('perform.active_job')
     expect(metric).must_be :present?
     expect(metric['AppName']).must_equal 'Dummy'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,7 +21,8 @@ class LambdakiqSpec < Minitest::Spec
           TestHelper::EventHelpers,
           TestHelper::QueueHelpers,
           TestHelper::LogHelpers,
-          TestHelper::PerformHelpers
+          TestHelper::PerformHelpers,
+          TestHelper::ResponseHelpers
 
   before do
     client_reset!

--- a/test/test_helper/event_helpers.rb
+++ b/test/test_helper/event_helpers.rb
@@ -1,5 +1,6 @@
 require 'test_helper/events/base'
 require 'test_helper/events/basic'
+require 'securerandom'
 
 module TestHelper
   module EventHelpers

--- a/test/test_helper/event_helpers.rb
+++ b/test/test_helper/event_helpers.rb
@@ -5,14 +5,16 @@ require 'securerandom'
 module TestHelper
   module EventHelpers
 
+    MESSAGE_ID = '9081fe74-bc79-451f-a03a-2fe5c6e2f807'.freeze
+
     private
 
     def event_basic(overrides = {})
       Events::Basic.create(overrides)
     end
 
-    def event_basic_delay(minutes: 5, timestamp: Time.current.strftime('%s%3N'))
-      Events::Basic.create(
+    def event_basic_delay(minutes: 5, timestamp: Time.current.strftime('%s%3N'), overrides: {})
+      Events::Basic.create({
         attributes: { SentTimestamp: timestamp },
         messageAttributes: {
           delay_seconds: {
@@ -22,7 +24,11 @@ module TestHelper
             dataType: 'String'
           }
         }
-      )
+      }.merge(overrides))
+    end
+
+    def message_id
+      MESSAGE_ID
     end
 
   end

--- a/test/test_helper/events/base.rb
+++ b/test/test_helper/events/base.rb
@@ -6,6 +6,7 @@ module TestHelper
       self.event = Hash.new
 
       def self.create(overrides = {})
+        overrides[:messageId] ||= SecureRandom.uuid
         job_class = overrides.delete(:job_class)
         event.deep_dup.tap do |e|
           e['Records'].each do |r|

--- a/test/test_helper/events/basic.rb
+++ b/test/test_helper/events/basic.rb
@@ -6,7 +6,7 @@ module TestHelper
         {
             "Records": [
                 {
-                    "messageId": "9081fe74-bc79-451f-a03a-2fe5c6e2f807",
+                    "messageId": "abcdefgh-ijkl-mnop-qrst-uvwxyz012345",
                     "receiptHandle": "AQEBgbn8GmF1fMo4z3IIqlJYymS6e7NBynwE+LsQlzjjdcKtSIomGeKMe0noLC9UDShUSe8bzr0s+pby03stHNRv1hgg4WRB5YT4aO0dwOuio7LvMQ/VW88igQtWmca78K6ixnU9X5Sr6J+/+WMvjBgIdvO0ycAM2tyJ1nxRHs/krUoLo/bFCnnwYh++T5BLQtFjFGrRkPjWnzjAbLWKU6Hxxr5lkHSxGhjfAoTCOjhi9crouXaWD+H1uvoGx/O/ZXaeMNjKIQoKjhFguwbEpvrq2Pfh2x9nRgBP3cKa9qw4Q3oFQ0MiQAvnK+UO8cCnsKtD",
                     "body": "{\"job_class\":\"TestHelper::Jobs::BasicJob\",\"job_id\":\"527cd37e-08f4-4aa8-9834-a46220cdc5a3\",\"provider_job_id\":null,\"queue_name\":\"lambdakiq-JobsQueue-TESTING123.fifo\",\"priority\":null,\"arguments\":[\"test\"],\"executions\":0,\"exception_executions\":{},\"locale\":\"en\",\"timezone\":\"UTC\",\"enqueued_at\":\"2020-11-30T13:07:36Z\"}",
                     "attributes": {

--- a/test/test_helper/response_helpers.rb
+++ b/test/test_helper/response_helpers.rb
@@ -1,0 +1,27 @@
+module TestHelper
+  module ResponseHelpers
+    extend ActiveSupport::Concern
+
+    private
+
+    def assert_response(response, failures: false, identifiers: [])
+      expect(response).must_be_instance_of Hash
+      expect(response[:BatchItemFailures]).must_be_instance_of Array
+      if failures
+        assert_response_failures response, identifiers: identifiers
+      else
+        expect(response[:BatchItemFailures]).must_be :empty?
+      end
+    end
+
+    def assert_response_failures(response, identifiers: [])
+      expect(response[:BatchItemFailures]).wont_be :empty?
+      return if identifiers.blank?
+      expect(response[:BatchItemFailures].length).must_equal identifiers.length
+      response[:BatchItemFailures].each_with_index do |failure, index|
+        expect(failure[:ItemIdentifier]).must_equal identifiers[index]
+      end
+    end
+
+  end
+end

--- a/test/test_helper/response_helpers.rb
+++ b/test/test_helper/response_helpers.rb
@@ -6,20 +6,20 @@ module TestHelper
 
     def assert_response(response, failures: false, identifiers: [])
       expect(response).must_be_instance_of Hash
-      expect(response[:BatchItemFailures]).must_be_instance_of Array
+      expect(response[:batchItemFailures]).must_be_instance_of Array
       if failures
         assert_response_failures response, identifiers: identifiers
       else
-        expect(response[:BatchItemFailures]).must_be :empty?
+        expect(response[:batchItemFailures]).must_be :empty?
       end
     end
 
     def assert_response_failures(response, identifiers: [])
-      expect(response[:BatchItemFailures]).wont_be :empty?
+      expect(response[:batchItemFailures]).wont_be :empty?
       return if identifiers.blank?
-      expect(response[:BatchItemFailures].length).must_equal identifiers.length
-      response[:BatchItemFailures].each_with_index do |failure, index|
-        expect(failure[:ItemIdentifier]).must_equal identifiers[index]
+      expect(response[:batchItemFailures].length).must_equal identifiers.length
+      response[:batchItemFailures].each_with_index do |failure, index|
+        expect(failure[:itemIdentifier]).must_equal identifiers[index]
       end
     end
 


### PR DESCRIPTION
The idea here is to support the newly released (https://aws.amazon.com/about-aws/whats-new/2021/11/aws-lambda-partial-batch-response-sqs-event-source/) SQS features for per item batch failures with SQS. The docs can be found here  (https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting) with some typos because the case of the interface is wrong. See https://github.com/awsdocs/aws-lambda-developer-guide/issues/320

## Benefits

- Never return errors from the handler. Avoid concurrence blocks!!!
- Allow folks to use whatever Batch size makes sense for them.