### PR TITLE
Rails 5.1 oddities for class attribute default not set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v2.0.1
+
+#### Fixed
+
+- Rails 5.1 oddities for class attribute default not set.
+
 ## v2.0.0
 
 #### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lambdakiq (2.0.0)
+    lambdakiq (2.0.1)
       activejob
       aws-sdk-sqs
       concurrent-ruby

--- a/lib/lambdakiq/version.rb
+++ b/lib/lambdakiq/version.rb
@@ -1,3 +1,3 @@
 module Lambdakiq
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/lib/lambdakiq/worker.rb
+++ b/lib/lambdakiq/worker.rb
@@ -4,8 +4,8 @@ module Lambdakiq
 
     included do
       class_attribute :lambdakiq_options_hash,
-                      instance_predicate: false,
-                      default: Hash.new
+                      instance_predicate: false
+      self.lambdakiq_options_hash = Hash.new
     end
 
     class_methods do


### PR DESCRIPTION
```
MyJob.perform_later(key)
irb(main):009:0> end
Traceback (most recent call last):
        3: from (irb):7
        2: from (irb):7:in `each'
        1: from (irb):8:in `block in irb_binding'
NoMethodError (undefined method `[]' for nil:NilClass)
```