### PR TITLE
Ensure failed messages go to DLQ

### DIFF
--- a/lib/lambdakiq/queue.rb
+++ b/lib/lambdakiq/queue.rb
@@ -22,11 +22,11 @@ module Lambdakiq
     end
 
     def redrive_policy
-      @redrive_policy ||= JSON.parse(attributes['RedrivePolicy'])
+      @redrive_policy ||= attributes['RedrivePolicy'] ? JSON.parse(attributes['RedrivePolicy']) : nil
     end
 
     def max_receive_count
-      redrive_policy['maxReceiveCount'].to_i
+      redrive_policy&.dig('maxReceiveCount')&.to_i || 1
     end
 
     def fifo?

--- a/test/cases/jobs/basic_job_nofifo_job_test.rb
+++ b/test/cases/jobs/basic_job_nofifo_job_test.rb
@@ -6,7 +6,7 @@ class BasicJobNofifoTest < LambdakiqSpec
     expect(sent_message).must_be :present?
   end
 
-  it 'message body has no fifo queue nave vs fifo super class ' do
+  it 'message body has no fifo queue name vs fifo super class ' do
     expect(sent_message_body['queue_name']).must_equal 'lambdakiq-JobsQueue-TESTING123'
   end
 

--- a/test/cases/queue_test.rb
+++ b/test/cases/queue_test.rb
@@ -1,13 +1,20 @@
 require 'test_helper'
 
 class QueueTest < LambdakiqSpec
-  let(:queue) { Lambdakiq.client.queues[queue_name] }
+  let(:fifo_queue) { Lambdakiq.client.queues[queue_name] }
+  let(:non_fifo_queue) { Lambdakiq.client.queues['non-fifo-queue'] }
 
   it '#fifo?' do
-    expect(queue.fifo?).must_equal true
+    expect(fifo_queue.fifo?).must_equal true
+    expect(non_fifo_queue.fifo?).must_equal false
   end
 
-  it '#max_receive_count' do
-    expect(queue.max_receive_count).must_equal 8
+  it '#max_receive_count returns the queue redrive policy maxReceiveCount' do
+    expect(fifo_queue.max_receive_count).must_equal 8
+  end
+
+  it '#max_receive_count returns 1 when the queue does not have a redrive policy' do
+    client.stub_responses(:get_queue_attributes, { attributes: {} })
+    expect(fifo_queue.max_receive_count).must_equal 1
   end
 end


### PR DESCRIPTION
### Description

When SQS is configured with a redrive policy into a dead letter queue, jobs that have not been processed correctly should end up in the DLQ after reaching the configured max receive count.

### Changes

Messages will no longer be deleted from the queue after failing for the max receive count configured in the queue, and therefore SQS will handle sending messages to the DLQ.
If the main lambdakiq retry config, or a specific job retry config is less than the queue retry number, then the messages will still be deleted, otherwise SQS would continue to execute lambda until the queue max receive is reached and the configuration of retries would not be honored.
