### PR TITLE
cloudwatch metrics can be turned off

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ config.lambdakiq
 - `max_retries=` - Retries for all jobs. Default is the Lambdakiq maximum of `12`.
 - `metrics_namespace=` - The CloudWatch Embedded Metrics namespace. Default is `Lambdakiq`.
 - `metrics_logger=` - Set to the Rails logger which is STDOUT via Lamby/Lambda.
+- `send_cloud_watch_metrics` - Set to `true` to enable CloudWatch metrics. Default is `true`.
 
 ### ActiveJob Configs
 

--- a/lib/lambdakiq/metrics.rb
+++ b/lib/lambdakiq/metrics.rb
@@ -17,6 +17,7 @@ module Lambdakiq
 
     def log
       return unless lambdakiq?
+      return unless Lambdakiq.config.send_cloud_watch_metrics
       logger.info JSON.dump(message)
     end
 

--- a/lib/lambdakiq/railtie.rb
+++ b/lib/lambdakiq/railtie.rb
@@ -3,6 +3,7 @@ module Lambdakiq
     config.lambdakiq = ActiveSupport::OrderedOptions.new
     config.lambdakiq.max_retries = 12
     config.lambdakiq.metrics_namespace = 'Lambdakiq'
+    config.lambdakiq.send_cloud_watch_metrics = true
 
     config.after_initialize do
       config.active_job.logger = Rails.logger

--- a/test/cases/job_test.rb
+++ b/test/cases/job_test.rb
@@ -43,6 +43,15 @@ class JobTest < LambdakiqSpec
     expect(metric['JobArg1']).must_equal 'test'
   end
 
+  it 'does not log cloudwatch embedded metrics when disabled' do
+    Lambdakiq.config.send_cloud_watch_metrics = false
+    response = Lambdakiq::Job.handler(event_basic(messageId: message_id))
+    assert_response response, failures: false
+    metric = logged_metric('perform.active_job')
+    expect(metric).must_be_nil
+    Lambdakiq.config.send_cloud_watch_metrics = true
+  end
+
   it 'must change message visibility to next value for failed jobs' do
     event = event_basic attributes: { ApproximateReceiveCount: '7' }, job_class: 'TestHelper::Jobs::ErrorJob', messageId: message_id
     response = Lambdakiq::Job.handler(event)


### PR DESCRIPTION
Add the `Lambdakiq.config.send_cloud_watch_metrics` variable to deactivate the cloudwatch events. CloudWatch events are activated by default.